### PR TITLE
HW-convolution: fix typo in xrt.ini

### DIFF
--- a/Hardware_Acceleration/Design_Tutorials/01-convolution-tutorial/xrt.ini
+++ b/Hardware_Acceleration/Design_Tutorials/01-convolution-tutorial/xrt.ini
@@ -1,5 +1,5 @@
 [Debug]
-opencl_sumary=true
+opencl_summary=true
 opencl_trace=true
 data_transfer_trace=fine
 trace_buffer_size=4G


### PR DESCRIPTION
Summary must be with two 'm'