### PR TITLE
AIE 06_fft2d: Removed redefinition of DSPLIB_ROOT in makefile

### DIFF
--- a/AI_Engine_Development/Design_Tutorials/06-fft2d_AIEvsHLS/AIE/Makefile
+++ b/AI_Engine_Development/Design_Tutorials/06-fft2d_AIEvsHLS/AIE/Makefile
@@ -103,8 +103,6 @@ help::
 # Print all options passed to Makefile
 print-%  : ; @echo $* = $($*)
 
-# For SPRITE
-DSPLIB_ROOT=$(DSPLIB_VITIS)/dsp
 
 # =========================================================
 # TARGET can be set as:


### PR DESCRIPTION
DSPLIB_ROOT is already defined in environment set up