### PR TITLE
Getting_Started: resolve errors of cl::Buffer

### DIFF
--- a/Getting_Started/Vitis/Part4-data_center.md
+++ b/Getting_Started/Vitis/Part4-data_center.md
@@ -155,7 +155,9 @@ When the run completes, you should see the TEST PASSED message indicating that t
 
 ### Targeting Hardware
 
-To build for the hardware target, , enter the following commands to setup the target build directory:
+*NOTE: Don't forget to unset the XCL_EMULATION_MODE environment varaible when running the hardware target or an error will occur.*
+
+To build for the hardware target enter the following commands to setup the target build directory:
 
 ```bash
 cd <Path to the cloned repo>/Getting_Started/Vitis/example/u200

--- a/Getting_Started/Vitis/example/src/host.cpp
+++ b/Getting_Started/Vitis/example/src/host.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
     // Create the buffers and allocate memory
     cl::Buffer in1_buf(context, CL_MEM_READ_ONLY, sizeof(int) * DATA_SIZE, NULL, &err);
     cl::Buffer in2_buf(context, CL_MEM_READ_ONLY, sizeof(int) * DATA_SIZE, NULL, &err);
-    cl::Buffer out_buf(context, CL_MEM_WRITE_ONLY, sizeof(int) * DATA_SIZE, NULL, &err);
+    cl::Buffer out_buf(context, CL_MEM_READ_WRITE, sizeof(int) * DATA_SIZE, NULL, &err);
 
     // Map buffers to kernel arguments, thereby assigning them to specific device memory banks
     krnl_vector_add.setArg(0, in1_buf);

--- a/Hardware_Acceleration/Feature_Tutorials/01-rtl_kernel_workflow/reference-files/xrt.ini
+++ b/Hardware_Acceleration/Feature_Tutorials/01-rtl_kernel_workflow/reference-files/xrt.ini
@@ -1,2 +1,2 @@
 [Debug]
-opencl_summary=true
+native_xrt_trace=true


### PR DESCRIPTION
Comment to Getting Started > Vitis to prevent user-error
Update xrt.ini to allow run_summary to be generated
Update Getting Started > Vitis host.cpp to enable hw build to run