### PR TITLE
AIE/F/05-integration: Clarification for environment variables ROOTFS and IMAGE set up

### DIFF
--- a/AI_Engine_Development/Feature_Tutorials/05-AI-engine-versal-integration/README.md
+++ b/AI_Engine_Development/Feature_Tutorials/05-AI-engine-versal-integration/README.md
@@ -24,7 +24,7 @@ This tutorial steps through software emulation, hardware emulation and hardware 
 Before starting this tutorial run the following steps:
 
 1. Set up your platform by running the `xilinx-versal-common-v2022.1/environment-setup-cortexa72-cortexa53-xilinx-linux` script as provided in the platform download. This script sets up the `SDKTARGETSYSROOT` and `CXX` variables. If the script is not present, you **must** run the `xilinx-versal-common-v2022.1/sdk.sh`.
-2. Set up your `ROOTFS`, and `IMAGE` to point to the `xilinx-versal-common-v2022.1` directory.
+2. Set up your `ROOTFS`, and `IMAGE` to point to the rootfs.ext4 and Image files located in the `xilinx-versal-common-v2022.1` directory.
 3. Set up your `PLATFORM_REPO_PATHS` environment variable based upon where you downloaded the platform.
 
 This tutorial targets VCK190 production board for 2022.1 version. 


### PR DESCRIPTION
Clarified that environment variables ROOTFS and IMAGE should be set to point to the rootfs and image files