### PR TITLE
[Contrib/01-Thin-PFM] Separated XPFM_LINUX_PRE_BUILDS in XPFM_PRE_BUILDS and LINUX_PRE_BUILDS to allow more build options

### DIFF
--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/.gitignore
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/.gitignore
@@ -49,6 +49,8 @@ platform/hw/board_repo
 linux/vck190-versal
 linux/vck190-versal-meta
 linux/sysroot
+linux/dtg/dts
+linux/dtg/device-tree-xlnx
 ip/*/.ipcache
 ip/*/_x
 ip/*/*.xml

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/Makefile
@@ -31,8 +31,11 @@ VITIS_VERSION                     := $(shell vitis -version 2>/dev/null | grep "
 # TARGET = hw or hw_emu
 export TARGET                     := hw
 
-# XPFM_LINUX_PRE_BUILDS = false (Build xpfm and linux) or true (Use pre-builds)
-export XPFM_LINUX_PRE_BUILDS      := false
+# XPFM_PRE_BUILDS = false (Build xpfm) or true (Use xpfm pre-builds)
+export XPFM_PRE_BUILDS            := false
+
+# LINUX_PRE_BUILDS = false (Build linux) or true (Use linux pre-builds)
+export LINUX_PRE_BUILDS           := false
 
 # ILA_EN = 0 (Disabled) or 1 (Enabled)
 export ILA_EN                     := 0
@@ -67,15 +70,31 @@ export LINUX_ETH_CONFIG           := DHCP
 ################################################################
 export DEVICE_NAME                := xcvc1902-vsva2197-2MP-e-S
 export PLATFORM_CUSTOM            := vck190_thin
+export PLATFORM_PRE_BUILD         := xilinx_vck190_base_202220_1
 export LINUX_MACHINE              := vck190-versal
 
 LINUX_SRC_DIR                     := ./linux/src
 LINUX_BUILD_DIR                   := ./linux/${LINUX_MACHINE}
-LINUX_IMAGES                      := ${LINUX_BUILD_DIR}/images/linux
+LINUX_DTB_DIR                     := ./linux/dtg/dts
 
+XSA_DIR                           := ./platform/hw/build
+XSA_FILE                          := ${XSA_DIR}/${PLATFORM_CUSTOM}.xsa
+XSA_PRE_BUILD                     := ${PLATFORM_REPO_PATHS}/${PLATFORM_PRE_BUILD}/hw/hw.xsa
 XPFM_EXPORT                       := ./platform/sw/build/${PLATFORM_CUSTOM}/export/${PLATFORM_CUSTOM}
-XPFM_PRE_BUILT                    := ${PLATFORM_REPO_PATHS}/xilinx_vck190_base_202220_1
+XPFM_PRE_BUILD                    := ${PLATFORM_REPO_PATHS}/${PLATFORM_PRE_BUILD}
 BOARD_REPO                        := ./platform/hw/board_repo
+
+ifeq (${LINUX_PRE_BUILDS}, false)
+  LINUX_SRC_IMAGES                := ${LINUX_BUILD_DIR}/images/linux
+else
+  LINUX_SRC_IMAGES                := ${PLATFORM_REPO_PATHS}/${PLATFORM_PRE_BUILD}/sw/${PLATFORM_PRE_BUILD}/boot
+endif
+
+ifeq (${XPFM_PRE_BUILDS}, false)
+  BOOT_SRC_EXPORT                 := ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/xrt/image/boot.scr
+else
+  BOOT_SRC_EXPORT                 := ${XPFM_EXPORT}/sw/${PLATFORM_PRE_BUILD}/xrt/image/boot.scr
+endif
 
 ################################################################
 # Variables needed to shorten he build process when TRYING out #
@@ -137,7 +156,7 @@ help::
 	$(ECHO) "  make clean"
 	$(ECHO) "      Command to remove all the generated files."
 
-all: version_check ${BOARD_REPO} xsa linux xpfm bif ip ps_apps vitis
+all: version_check ${BOARD_REPO} xsa linux dtg xpfm bif ip ps_apps vitis
 
 all_targets:
 	$(MAKE) all TARGET=hw
@@ -167,30 +186,44 @@ endif
 	$(ECHO) "AMD/XILINX TOOLS & VERSION CHECK SUCCESSFUL"
 
 ${BOARD_REPO}:
-ifeq (${XPFM_LINUX_PRE_BUILDS}, false)
+ifeq (${XPFM_PRE_BUILDS}, false)
 	git clone https://github.com/Xilinx/XilinxBoardStore.git ${BOARD_REPO}
 endif
 
 xsa:
-ifeq (${XPFM_LINUX_PRE_BUILDS}, false)
+ifeq (${XPFM_PRE_BUILDS}, true)
+	$(MAKE) xsa_pre_build
+else
 	$(MAKE) xsa -C platform
 endif
 
+xsa_pre_build: ${XSA_FILE}
+${XSA_FILE}:
+	mkdir -p  ${XSA_DIR}
+	ln    -s  ${XSA_PRE_BUILD} ${XSA_FILE}
+
 linux:
-ifeq (${XPFM_LINUX_PRE_BUILDS}, true)
+ifeq (${LINUX_PRE_BUILDS}, true)
 	$(MAKE) linux_pre_build
 else ifeq (${LINUX_BUILD_SKIP}, false)
 	$(MAKE) all -C linux/${LINUX_BUILD_TOOL}
 else
-	touch ${LINUX_IMAGES}/*
+	touch ${LINUX_SRC_IMAGES}/*
 endif
 
 linux_pre_build: ./linux/sysroot
 ./linux/sysroot:
 	ln -s $(abspath ${SDKTARGETSYSROOT}/../..) ./linux/sysroot	
 
+dtg:
+ifeq (${XPFM_PRE_BUILDS}, false)
+ifeq (${LINUX_PRE_BUILDS}, true)
+	$(MAKE) all -C linux/dtg
+endif
+endif
+
 xpfm:
-ifeq (${XPFM_LINUX_PRE_BUILDS}, true)
+ifeq (${XPFM_PRE_BUILDS}, true)
 	$(MAKE) xpfm_pre_build
 else 
 	$(MAKE) xpfm -C platform
@@ -199,22 +232,38 @@ endif
 xpfm_pre_build: ${XPFM_EXPORT}
 ${XPFM_EXPORT}:
 	mkdir -p  ${XPFM_EXPORT}
-	cp    -rf ${XPFM_PRE_BUILT}/*                              ${XPFM_EXPORT}
-	mv    -f  ${XPFM_EXPORT}/xilinx_vck190_base_202220_1.xpfm  ${XPFM_EXPORT}/${PLATFORM_CUSTOM}.xpfm
+	cp    -rf ${XPFM_PRE_BUILD}/*                           ${XPFM_EXPORT}
+	mv    -f  ${XPFM_EXPORT}/${PLATFORM_PRE_BUILD}.xpfm     ${XPFM_EXPORT}/${PLATFORM_CUSTOM}.xpfm
 
-bif:
-ifeq (${XPFM_LINUX_PRE_BUILDS}, false)
-	$(MAKE)  ${XPFM_EXPORT}/sw/Image
+bif: 
+ifeq (${LINUX_PRE_BUILDS}, false)
+	$(MAKE) ${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot
+else 
+	$(MAKE) ${XPFM_EXPORT}/sw/rootfs.ext4
+ifeq (${XPFM_PRE_BUILDS}, false)
+	$(MAKE) ${XPFM_EXPORT}/sw/system.dtb
+endif
 endif
 
-${XPFM_EXPORT}/sw/Image: ${LINUX_IMAGES}/* ${LINUX_SRC_DIR}/boot_custom.bif
-	cp -f ${LINUX_IMAGES}/u-boot.elf             ${XPFM_EXPORT}/sw/u-boot.elf
-	cp -f ${LINUX_IMAGES}/system.dtb             ${XPFM_EXPORT}/sw/system.dtb
-	cp -f ${LINUX_IMAGES}/bl31.elf               ${XPFM_EXPORT}/sw/bl31.elf
-	cp -f ${LINUX_IMAGES}/Image                  ${XPFM_EXPORT}/sw/Image
-	cp -f ${LINUX_IMAGES}/rootfs.cpio.gz.u-boot  ${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot
-	cp -f ${LINUX_IMAGES}/boot.scr               ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/xrt/image/boot.scr
-	cp -f ${LINUX_SRC_DIR}/boot_custom.bif       ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/boot/linux.bif
+${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot: ${LINUX_SRC_IMAGES}/rootfs.cpio.gz.u-boot ${LINUX_SRC_DIR}/boot_custom.bif ${LINUX_DTB_DIR}/system-top.dtb
+	cp -f ${LINUX_SRC_DIR}/boot_custom.bif                    ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/boot/linux.bif
+	cp -f ${LINUX_SRC_IMAGES}/system.dtb                      ${XPFM_EXPORT}/sw/system.dtb
+	cp -f ${LINUX_SRC_IMAGES}/u-boot.elf                      ${XPFM_EXPORT}/sw/u-boot.elf
+	cp -f ${LINUX_SRC_IMAGES}/bl31.elf                        ${XPFM_EXPORT}/sw/bl31.elf
+	cp -f ${LINUX_SRC_IMAGES}/Image                           ${XPFM_EXPORT}/sw/Image
+	cp -f ${LINUX_SRC_IMAGES}/rootfs.cpio.gz.u-boot           ${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot
+	cp -f ${LINUX_SRC_IMAGES}/boot.scr                        ${BOOT_SRC_EXPORT}
+
+${XPFM_EXPORT}/sw/rootfs.ext4: ${SDKTARGETSYSROOT}/../../rootfs.ext4
+	cp -f ${SDKTARGETSYSROOT}/../../Image                     ${XPFM_EXPORT}/sw/Image
+	cp -f ${SDKTARGETSYSROOT}/../../rootfs.ext4               ${XPFM_EXPORT}/sw/rootfs.ext4
+	cp -f ${SDKTARGETSYSROOT}/../../boot.scr                  ${BOOT_SRC_EXPORT}
+
+${XPFM_EXPORT}/sw/system.dtb: ${LINUX_SRC_DIR}/boot_custom.bif ${LINUX_DTB_DIR}/system-top.dtb
+	cp -f ${LINUX_SRC_DIR}/boot_custom.bif                    ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/boot/linux.bif
+	cp -f ${LINUX_DTB_DIR}/system-top.dtb                     ${XPFM_EXPORT}/sw/system.dtb
+	cp -f ${SDKTARGETSYSROOT}/../../u-boot.elf                ${XPFM_EXPORT}/sw/u-boot.elf
+	cp -f ${SDKTARGETSYSROOT}/../../bl31.elf                  ${XPFM_EXPORT}/sw/bl31.elf
 
 ip:
 	$(MAKE) all -C ip
@@ -237,6 +286,7 @@ ultraclean_vitis:
 clean:
 	$(MAKE) clean -C platform
 	$(MAKE) clean -C linux/${LINUX_BUILD_TOOL}
+	$(MAKE) clean -C linux/dtg
 	$(MAKE) clean_vitis
 	rm -rf ${BOARD_REPO}
 

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/Makefile
@@ -80,20 +80,25 @@ LINUX_DTB_DIR                     := ./linux/dtg/dts
 XSA_DIR                           := ./platform/hw/build
 XSA_FILE                          := ${XSA_DIR}/${PLATFORM_CUSTOM}.xsa
 XSA_PRE_BUILD                     := ${PLATFORM_REPO_PATHS}/${PLATFORM_PRE_BUILD}/hw/hw.xsa
+
 XPFM_EXPORT                       := ./platform/sw/build/${PLATFORM_CUSTOM}/export/${PLATFORM_CUSTOM}
+XPFM_EXPORT_SW                    := ${XPFM_EXPORT}/sw
 XPFM_PRE_BUILD                    := ${PLATFORM_REPO_PATHS}/${PLATFORM_PRE_BUILD}
+
 BOARD_REPO                        := ./platform/hw/board_repo
 
 ifeq (${LINUX_PRE_BUILDS}, false)
   LINUX_SRC_IMAGES                := ${LINUX_BUILD_DIR}/images/linux
 else
-  LINUX_SRC_IMAGES                := ${PLATFORM_REPO_PATHS}/${PLATFORM_PRE_BUILD}/sw/${PLATFORM_PRE_BUILD}/boot
+  LINUX_SRC_IMAGES                := ${SDKTARGETSYSROOT}/../..
 endif
 
 ifeq (${XPFM_PRE_BUILDS}, false)
-  BOOT_SRC_EXPORT                 := ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/xrt/image/boot.scr
+  XPFM_EXPORT_BOOT                := ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/boot
+  XPFM_EXPORT_XRT_IMAGE           := ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/xrt/image
 else
-  BOOT_SRC_EXPORT                 := ${XPFM_EXPORT}/sw/${PLATFORM_PRE_BUILD}/xrt/image/boot.scr
+  XPFM_EXPORT_BOOT                := ${XPFM_EXPORT}/sw/${PLATFORM_PRE_BUILD}/boot
+  XPFM_EXPORT_XRT_IMAGE           := ${XPFM_EXPORT}/sw/${PLATFORM_PRE_BUILD}/xrt/image
 endif
 
 ################################################################
@@ -169,6 +174,11 @@ endif
 ifeq (,$(findstring $(REQUIRED_VERSION),$(VIVADO_VERSION)))
 	$(ECHO) "[ERROR] Vivado $(REQUIRED_VERSION) NOT found, please setup Vivado correctly!"; exit 1
 endif
+ifeq (${LINUX_PRE_BUILDS}, true)
+ifndef SDKTARGETSYSROOT
+	$(ECHO) "[ERROR] SDKTARGETSYSROOT NOT found, please setup SDKTARGETSYSROOT correctly!"; exit 1
+endif
+else
 ifeq (${LINUX_BUILD_TOOL}, petalinux)
 ifndef PETALINUX_VER
 	$(ECHO) "[ERROR] Petalinux NOT found, please setup Petalinux correctly!"; exit 1
@@ -177,11 +187,17 @@ ifeq (,$(findstring $(REQUIRED_VERSION),$(PETALINUX_VER)))
 	$(ECHO) "[ERROR] Petalinux $(REQUIRED_VERSION) NOT found, please setup Petalinux correctly!"; exit 1
 endif
 endif
+endif
 ifndef VITIS_VERSION
 	$(ECHO) "[ERROR] Vitis NOT found, please setup Vitis correctly!"; exit 1
 endif
 ifeq (,$(findstring $(REQUIRED_VERSION),$(VITIS_VERSION)))
 	$(ECHO) "[ERROR] Vitis $(REQUIRED_VERSION) NOT found, please setup Vitis correctly!"; exit 1
+endif
+ifeq (${XPFM_PRE_BUILDS}, true)
+ifndef PLATFORM_REPO_PATHS
+	$(ECHO) "[ERROR] PLATFORM_REPO_PATHS NOT found, please setup PLATFORM_REPO_PATHS correctly!"; exit 1
+endif
 endif
 	$(ECHO) "AMD/XILINX TOOLS & VERSION CHECK SUCCESSFUL"
 
@@ -234,36 +250,40 @@ ${XPFM_EXPORT}:
 	mkdir -p  ${XPFM_EXPORT}
 	cp    -rf ${XPFM_PRE_BUILD}/*                           ${XPFM_EXPORT}
 	mv    -f  ${XPFM_EXPORT}/${PLATFORM_PRE_BUILD}.xpfm     ${XPFM_EXPORT}/${PLATFORM_CUSTOM}.xpfm
+	mv    -f  ${XPFM_EXPORT_BOOT}/*                         ${XPFM_EXPORT_SW}
+	rm    -rf ${XPFM_EXPORT_SW}/*.bif
 
 bif: 
+	$(MAKE) ${XPFM_EXPORT_BOOT}/linux.bif
 ifeq (${LINUX_PRE_BUILDS}, false)
-	$(MAKE) ${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot
+	$(MAKE) ${XPFM_EXPORT_SW}/rootfs.cpio.gz.u-boot
 else 
-	$(MAKE) ${XPFM_EXPORT}/sw/rootfs.ext4
+	$(MAKE) ${XPFM_EXPORT_SW}/rootfs.ext4
 ifeq (${XPFM_PRE_BUILDS}, false)
-	$(MAKE) ${XPFM_EXPORT}/sw/system.dtb
+	$(MAKE) ${XPFM_EXPORT_SW}/system.dtb
 endif
 endif
 
-${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot: ${LINUX_SRC_IMAGES}/rootfs.cpio.gz.u-boot ${LINUX_SRC_DIR}/boot_custom.bif ${LINUX_DTB_DIR}/system-top.dtb
-	cp -f ${LINUX_SRC_DIR}/boot_custom.bif                    ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/boot/linux.bif
-	cp -f ${LINUX_SRC_IMAGES}/system.dtb                      ${XPFM_EXPORT}/sw/system.dtb
-	cp -f ${LINUX_SRC_IMAGES}/u-boot.elf                      ${XPFM_EXPORT}/sw/u-boot.elf
-	cp -f ${LINUX_SRC_IMAGES}/bl31.elf                        ${XPFM_EXPORT}/sw/bl31.elf
-	cp -f ${LINUX_SRC_IMAGES}/Image                           ${XPFM_EXPORT}/sw/Image
-	cp -f ${LINUX_SRC_IMAGES}/rootfs.cpio.gz.u-boot           ${XPFM_EXPORT}/sw/rootfs.cpio.gz.u-boot
-	cp -f ${LINUX_SRC_IMAGES}/boot.scr                        ${BOOT_SRC_EXPORT}
+${XPFM_EXPORT_BOOT}/linux.bif: ${LINUX_SRC_DIR}/boot_custom.bif
+	cp -f ${LINUX_SRC_DIR}/boot_custom.bif           ${XPFM_EXPORT_BOOT}/linux.bif
 
-${XPFM_EXPORT}/sw/rootfs.ext4: ${SDKTARGETSYSROOT}/../../rootfs.ext4
-	cp -f ${SDKTARGETSYSROOT}/../../Image                     ${XPFM_EXPORT}/sw/Image
-	cp -f ${SDKTARGETSYSROOT}/../../rootfs.ext4               ${XPFM_EXPORT}/sw/rootfs.ext4
-	cp -f ${SDKTARGETSYSROOT}/../../boot.scr                  ${BOOT_SRC_EXPORT}
+${XPFM_EXPORT_SW}/rootfs.cpio.gz.u-boot: ${LINUX_SRC_IMAGES}/rootfs.cpio.gz.u-boot
+	cp -f ${LINUX_SRC_IMAGES}/system.dtb             ${XPFM_EXPORT_SW}/system.dtb
+	cp -f ${LINUX_SRC_IMAGES}/u-boot.elf             ${XPFM_EXPORT_SW}/u-boot.elf
+	cp -f ${LINUX_SRC_IMAGES}/bl31.elf               ${XPFM_EXPORT_SW}/bl31.elf
+	cp -f ${LINUX_SRC_IMAGES}/Image                  ${XPFM_EXPORT_SW}/Image
+	cp -f ${LINUX_SRC_IMAGES}/rootfs.cpio.gz.u-boot  ${XPFM_EXPORT_SW}/rootfs.cpio.gz.u-boot
+	cp -f ${LINUX_SRC_IMAGES}/boot.scr               ${XPFM_EXPORT_XRT_IMAGE}/boot.scr
 
-${XPFM_EXPORT}/sw/system.dtb: ${LINUX_SRC_DIR}/boot_custom.bif ${LINUX_DTB_DIR}/system-top.dtb
-	cp -f ${LINUX_SRC_DIR}/boot_custom.bif                    ${XPFM_EXPORT}/sw/${PLATFORM_CUSTOM}/boot/linux.bif
-	cp -f ${LINUX_DTB_DIR}/system-top.dtb                     ${XPFM_EXPORT}/sw/system.dtb
-	cp -f ${SDKTARGETSYSROOT}/../../u-boot.elf                ${XPFM_EXPORT}/sw/u-boot.elf
-	cp -f ${SDKTARGETSYSROOT}/../../bl31.elf                  ${XPFM_EXPORT}/sw/bl31.elf
+${XPFM_EXPORT_SW}/rootfs.ext4: ${LINUX_SRC_IMAGES}/rootfs.ext4
+	cp -f ${LINUX_SRC_IMAGES}/Image                  ${XPFM_EXPORT_SW}/Image
+	cp -f ${LINUX_SRC_IMAGES}/rootfs.ext4            ${XPFM_EXPORT_SW}/rootfs.ext4
+	cp -f ${LINUX_SRC_IMAGES}/boot.scr               ${XPFM_EXPORT_XRT_IMAGE}/boot.scr
+
+${XPFM_EXPORT_SW}/system.dtb: ${LINUX_DTB_DIR}/system-top.dtb
+	cp -f ${LINUX_DTB_DIR}/system-top.dtb            ${XPFM_EXPORT_SW}/system.dtb
+	cp -f ${LINUX_SRC_IMAGES}/u-boot.elf             ${XPFM_EXPORT_SW}/u-boot.elf
+	cp -f ${LINUX_SRC_IMAGES}/bl31.elf               ${XPFM_EXPORT_SW}/bl31.elf
 
 ip:
 	$(MAKE) all -C ip

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/README.md
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/README.md
@@ -12,15 +12,16 @@ This tutorial describes a Versal VCK190 System Example Design based on a thin cu
 ### Build-flow
 The Versal VCK190 System Example Design full Makefile build-flow builds the whole project in the following order:
 ```
-  1. version_check: Checks if the Vivado, Petalinux and Vitis tools are setup and if the versions are 2022.2
-  2. board_repo:    Downloads the board files from the Xilinx GitHub 
-  3. xsa:           Building the thin platform xsa (only pre-synth)
-  4. linux:         Building linux and sysroot (with Petalinux or Yocto)
-  5. xpfm:          Building the Vitis Platform
-  6. bif:           Some necessary Copying of linux image-files to the software platform for a correct Vitis packaging
-  7. ip:            Building Ai Engine graph(s) towards libadf.a and compiling hls/rtl kernels to *.xo
-  8. ps_apps:       Building all XRT-based PS applications
-  9. vitis:         Linking all kernels in the thin platform and packaging all necessary boot/run files
+  1.  version_check: Checks if the Vivado, Petalinux and Vitis tools are setup and if the versions are 2022.2
+  2.  board_repo:    Downloads the board files from the Xilinx GitHub 
+  3.  xsa:           Building the thin platform xsa (only pre-synth) or using the pre-builds
+  4.  linux:         Building linux and sysroot (with Petalinux or Yocto) or using the pre-builds
+  5.  linux:         Building the device-tree when xsa and xpfm is build and using the linux pre-builds
+  6.  xpfm:          Building the Vitis Platform or using the pre-builds
+  7.  bif:           Some necessary Copying of linux image-files to the software platform for a correct Vitis packaging
+  8.  ip:            Building Ai Engine graph(s) towards libadf.a and compiling hls/rtl kernels to *.xo
+  9.  ps_apps:       Building all XRT-based PS applications
+  10. vitis:         Linking all kernels in the thin platform and packaging all necessary boot/run files
 ```
 ### Build-flow Dependencies
 The following diagram explains the build-flow dependencies.
@@ -58,19 +59,25 @@ In the `[project-root]` you can start the full build with `make all` or `make al
       - `export TARGET := hw_emu` for targetting hardware emulation (change if needed).
       - The build flow supports both TARGET's in the same `[project-root]`; if you need both results at once, you can do `make all_targets` from the `[project-root]`!
       - Some generated directories are depending on the `TARGET` selection and are further shown as `[dir]_${TARGET}`.
-    - `XPFM_LINUX_PRE_BUILDS`:
-      - `export XPFM_LINUX_PRE_BUILDS := false` for building xpfm and linux (default).
-      - `export XPFM_LINUX_PRE_BUILDS := true` for using the xpfm and linux pre-builds.
+    - `XPFM_PRE_BUILDS`:
+      - `export XPFM_PRE_BUILDS := false` for building xpfm (default).
+      - `export XPFM_PRE_BUILDS := true` for using the xpfm pre-builds.
         - Be sure that the environment `PLATFORM_REPO_PATHS` is set and pointing to the `internal_platforms` of the used version.
           - This should be set by sourcing Vivado `settingsXY.sh` and/or Vitis `settingsXY.sh`
+    - `LINUX_PRE_BUILDS`:
+      - `export LINUX_PRE_BUILDS := false` for building linux (default).
+      - `export LINUX_PRE_BUILDS := true` for using the linux pre-builds.
         - Download the `xilinx-versal-common-v2022.2_10141622.tar.gz` from the Xilinx Website and...
           - Extract it
           - cd xilinx-versal-common-v2022.2
           - xilinx-versal-common-v2022.2 $ ./sdk.sh
             - Enter target directory for SDK (default: /opt/petalinux/2022.2): `.`
+          - Make sure the sourcing Vivado `settingsXY.sh` and/or Vitis `settingsXY.sh` is done first!
+          - xilinx-versal-common-v2022.2 $ unset LD_LIBRARY_PATH
           - xilinx-versal-common-v2022.2 $ source environment-setup-cortexa72-cortexa53-xilinx-linux
-          - REMARK: The latter must be executed each time you start in a new terminal or when changing versions!
-      - REMARK: Following `LINUX_X_Y` exports are ignored and do not need setup when `export XPFM_LINUX_PRE_BUILDS := true`.
+          - REMARK: The latter 3 items must be executed each time you start in a new terminal or when changing versions!
+      - REMARK: Following `LINUX_X_Y` exports are ignored and do not need setup when `export LINUX_PRE_BUILDS := true`.
+      - REMARK: if `export XPFM_PRE_BUILDS := false` then a device-tree will be generated from the generated xsa. It could be - depending on the generated base platform (xsa) - that changes are needed in the `[project-root]/linux/dtg/src/system-user.dtsi` for a successfull build/boot. 
     - `ILA_EN`:
       - `export ILA_EN := 0` for disabling the ILA (default).
       - `export ILA_EN := 1` for enabling the ILA (change if needed).
@@ -116,7 +123,7 @@ In the `[project-root]` you can start the full build with `make all` or `make al
   - End result: 
     - `export TARGET := hw`: 
       - `[project-root]/package_output_hw/sd_card/*` can be used to copy to a FAT-32 SD-card (partition)
-        - REMARK: Can't be used when `export XPFM_LINUX_PRE_BUILDS := true` (due to only ext4 rootfs available)
+        - REMARK: Can't be used when `export LINUX_PRE_BUILDS := true` (due to only ext4 rootfs available)
       - `[project-root]/package_output_hw/sd_card.img` can be used to be put on an SD-card with a Windows tool like `Win32 Disk Imager` 
     - `export TARGET := hw_emu`: 
       - `[project-root]/package_output_hw_emu/launch_hw_emu.sh` can be used to launch the hardware emulation.
@@ -170,10 +177,13 @@ Each step is sequential (in the order listed - by the `[project-root]/Makefile`)
 | Makefile            | The platform xsa/xpfm Makefile                                  
 | hw/*                | The hardware platform Makefile and sources
 
- - Builds the output file needed for Petalinux/Yocto and Vitis software platform creation -> `[project-root]/platform/hw/build/vck190_thin.xsa`.
- - After this step you could open the platform blockdesign in Vivado for review:
-   - `[project-root]/platform/hw/build/vck190_thin_vivado` $ vivado `vck190_thin.xpr`
- 
+ - `export XPFM_PRE_BUILDS := false` 
+   - Builds the output file needed for Petalinux/Yocto and Vitis software platform creation -> `[project-root]/platform/hw/build/vck190_thin.xsa`.
+   - After this step you could open the platform blockdesign in Vivado for review:
+     - `[project-root]/platform/hw/build/vck190_thin_vivado` $ vivado `vck190_thin.xpr`
+ - `export XPFM_PRE_BUILDS := true` 
+   - Setup the project to use the pre-build xsa
+   
 </details>
 <details>
   <summary> make all -C linux/${LINUX_BUILD_TOOL} </summary>
@@ -198,9 +208,26 @@ Each step is sequential (in the order listed - by the `[project-root]/Makefile`)
 | Makefile            | The Yocto Makefile                                  
 | src/conf/auto.conf  | Yocto Build Configuration File
  
- - Builds all required linux (Petalinux or Yocto) images which end up in `[project-root]/linux/vck190-versal/images/linux`.
- - It also builds a `sysroot` which ends up in `[project-root]/linux/sysroot`; needed for `[project-root]/ps_apps` builds.
+ - `export LINUX_PRE_BUILDS := false` 
+   - Builds all required linux (Petalinux or Yocto) images which end up in `[project-root]/linux/vck190-versal/images/linux`.
+   - It also builds a `sysroot` which ends up in `[project-root]/linux/sysroot`; needed for `[project-root]/ps_apps` builds.
+ - `export LINUX_PRE_BUILDS := true` 
+   - Sets up the project to use the Linux pre-builds
+   
+</details>
+<details>
+  <summary> make all -C linux/dtg </summary>
+
+`[project-root]/linux/dtg` Directory/file structure:
+| Directory/file                                       | Description                                             
+| -----------------------------------------------------|-------------------------------------------------------------------------------------------
+| Makefile                                             | The device-tree generator Makefile              
+| src/build_dts.tcl                                    | XSCT-tcl-script used to build the device-tree out of a generated xsa              
+| src/system-user.dtsi                                 | Additional device-tree settings
  
+ - Only used when `export XPFM_PRE_BUILDS := false` and `export LINUX_PRE_BUILDS := true`
+   -  Builds the device-tree out of the generated xsa
+   
 </details>
 <details>
   <summary> make xpfm -C platform </summary>
@@ -211,9 +238,12 @@ Each step is sequential (in the order listed - by the `[project-root]/Makefile`)
 | Makefile            | The platform xsa/xpfm Makefile                                  
 | sw/*                | The Vitis platform Makefile and sources
 
- - Builds the platform needed for ip and Vitis   -> `[project-root]/platform/sw/build/vck190_thin/export/vck190_thin/vck190_thin.xpfm` 
- - Builds the software platform needed for Vitis -> `[project-root]/platform/sw/build/vck190_thin/export/vck190_thin/sw/*`
- 
+ - `export XPFM_PRE_BUILDS := false` 
+   - Builds the platform needed for ip and Vitis   -> `[project-root]/platform/sw/build/vck190_thin/export/vck190_thin/vck190_thin.xpfm` 
+   - Builds the software platform needed for Vitis -> `[project-root]/platform/sw/build/vck190_thin/export/vck190_thin/sw/*`
+ - `export XPFM_PRE_BUILDS := true` 
+   - Setup the project to use the xpfm pre-builds
+   
 </details>
 <details>
   <summary> make bif </summary>
@@ -281,7 +311,7 @@ Each step is sequential (in the order listed - by the `[project-root]/Makefile`)
 ## Testing
 ### Running on a VCK190
   1. Prerequisite: Build was executed with `export TARGET := hw`
-  2. Copy over the `[project-root]/package_output_hw/sd_card/*` to an SD-card (REMARK: Only when `export XPFM_LINUX_PRE_BUILDS := false`) or put the `[project-root]/package_output_hw/sd_card.img` on an SD-card.
+  2. Copy over the `[project-root]/package_output_hw/sd_card/*` to an SD-card (REMARK: Only when `export LINUX_PRE_BUILDS := false`) or put the `[project-root]/package_output_hw/sd_card.img` on an SD-card.
   3. Put the SD-card in the VCK190 Versal SD-card slot (VCK190 top SD-card slot closest to the bracket).
   4. Connect the included USB-cable between the VCK190 (Middle bottom of the bracket) and a computer:
      - Usually you will see 3 serial ports in your device manager:
@@ -309,7 +339,7 @@ Each step is sequential (in the order listed - by the `[project-root]/Makefile`)
 
 ### Execution & Results
 You will need to login with user `petalinux` and setup a new password (it's then also the `sudo` password):
-  - REMARK: It could be that if you used the `export XPFM_LINUX_PRE_BUILDS := true` that you get more messages displayed.
+  - REMARK: It could be that if you used the `export LINUX_PRE_BUILDS := true` that you get more messages displayed.
  ```
 vck190-versal login: petalinux
 You are required to change your password immediately (administrator enforced).
@@ -570,7 +600,7 @@ Click on each item below to see the detailed Revision History:
   <summary> December 2022 </summary>
   
  - general:
-   - Adding the option to use the xpfm and linux pre-builds
+   - Adding the option to use the xpfm and/or linux pre-builds
  
  </details>
 

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/README.md
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/README.md
@@ -16,7 +16,7 @@ The Versal VCK190 System Example Design full Makefile build-flow builds the whol
   2.  board_repo:    Downloads the board files from the Xilinx GitHub 
   3.  xsa:           Building the thin platform xsa (only pre-synth) or using the pre-builds
   4.  linux:         Building linux and sysroot (with Petalinux or Yocto) or using the pre-builds
-  5.  linux:         Building the device-tree when xsa and xpfm is build and using the linux pre-builds
+  5.  dtg:           Building the device-tree when xsa and xpfm is build and using the linux pre-builds
   6.  xpfm:          Building the Vitis Platform or using the pre-builds
   7.  bif:           Some necessary Copying of linux image-files to the software platform for a correct Vitis packaging
   8.  ip:            Building Ai Engine graph(s) towards libadf.a and compiling hls/rtl kernels to *.xo
@@ -72,7 +72,7 @@ In the `[project-root]` you can start the full build with `make all` or `make al
           - cd xilinx-versal-common-v2022.2
           - xilinx-versal-common-v2022.2 $ ./sdk.sh
             - Enter target directory for SDK (default: /opt/petalinux/2022.2): `.`
-          - Make sure the sourcing Vivado `settingsXY.sh` and/or Vitis `settingsXY.sh` is done first!
+          - Make sure sourcing Vivado `settingsXY.sh` and/or Vitis `settingsXY.sh` first!
           - xilinx-versal-common-v2022.2 $ unset LD_LIBRARY_PATH
           - xilinx-versal-common-v2022.2 $ source environment-setup-cortexa72-cortexa53-xilinx-linux
           - REMARK: The latter 3 items must be executed each time you start in a new terminal or when changing versions!
@@ -188,13 +188,13 @@ Each step is sequential (in the order listed - by the `[project-root]/Makefile`)
 <details>
   <summary> make all -C linux/${LINUX_BUILD_TOOL} </summary>
 
-`[project-root]/linux` Directory/file structure:
-| Directory/file                                       | Description                                             
-| -----------------------------------------------------|-------------------------------------------------------------------------------------------
-| src/recipes-bsp/device-tree/*                        | Linux-recipe and files needed for some device-tree changes needed for VCK190              
-| src/recipes-bsp/init-ifupdown/*                      | Linux-recipe and configuration file that needs to be setup for builds with `export LINUX_ETH_CONFIG := STATIC`
-| src/recipes-core/base-files/*                        | Linux-recipe needed to automount mmcblk0p1 for builds with `export LINUX_BUILD_TOOL := yocto`
-| src/boot_custom.bif                                  | Bif file with \<placeholders\> needed to have the Vitis packager generating a correct BOOT.BIN
+`[project-root]/linux/src` Directory/file structure:
+| Directory/file                                   | Description                                             
+| -------------------------------------------------|-------------------------------------------------------------------------------------------
+| recipes-bsp/device-tree/*                        | Linux-recipe and files needed for some device-tree changes needed for VCK190              
+| recipes-bsp/init-ifupdown/*                      | Linux-recipe and configuration file that needs to be setup for builds with `export LINUX_ETH_CONFIG := STATIC`
+| recipes-core/base-files/*                        | Linux-recipe needed to automount mmcblk0p1 for builds with `export LINUX_BUILD_TOOL := yocto`
+| boot_custom.bif                                  | Bif file with \<placeholders\> needed to have the Vitis packager generating a correct BOOT.BIN
  
  `[project-root]/linux/petalinux` Directory/file structure:
 | Directory/file      | Description                                             

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
@@ -68,20 +68,25 @@ ${DTC}:
 	export PATH=$PATH:${DTC_PATH}
 
 build_xsct:
+	$(ECHO) "dtg/build_xsct: Currently errors out, but should be the prefered method"
 	xsct -eval "createdts -hw ${XSA_FILE} -zocl -out . -platform-name vck190_thin -git-branch xlnx_rel_v2022.2 -dtsi ${DTSI_FILE} -compile"
 	cp ./vck190_thin/psv_cortexa72_0/device_tree_domain/bsp/system.dtb ${DTB_FILE}
 
 build_dts:
+	$(ECHO) "dtg/build_dts: Building the dts from the supplied xsa"
 	rm -rf ${DTS}
 	xsct -eval "source src/build_dts.tcl; build_dts $(XSA_FILE) ${DTS}"	
 
 include_board:
+	$(ECHO) "dtg/include_board: Currently not needed since included by the supplied xsa"
 	xsct -eval "source src/build_dts.tcl; include_board ${DTS}"
 
 include_dtsi:
+	$(ECHO) "dtg/include_dtsi: Adding custum specific parameters to the dts"
 	xsct -eval "source src/build_dts.tcl; include_dtsi ${DTSI_DIR} $(DTSI_FILE) ${DTS}"
 	
 build_dtb:
+	$(ECHO) "dtg/build_dtb: Building the dtb from the generated dts"
 	rm -rf ${DTB_FILE}
 	gcc -I ${DTS} -E -nostdinc -undef -D__DTS__ -x assembler-with-cpp -o ${DTS_FILE}.tmp ${DTS_FILE}
 	dtc -I dts -O dtb -@ -o ${DTB_FILE} ${DTS_FILE}.tmp

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
@@ -1,0 +1,100 @@
+ #
+ # Copyright 2021 Xilinx, Inc.
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+# Top-level Makefile -- Calls sub-makefiles
+
+ECHO                               = @echo
+
+################################################################################
+# Variables needed for AMD/XILINX tools version checking, PLEASE DO NOT MODIFY #
+################################################################################
+DTG                                := device-tree-xlnx
+DTG_VERSION                        := xlnx_rel_v2022.2
+
+DTC                                := dtc
+DTC_PATH                           := $(abspath ${DTC})
+
+DTS                                := dts
+
+XSA_FILE                           := $(wildcard ../../platform/hw/build/*.xsa)
+DTSI_DIR                           := ./src
+DTSI_FILE                          := system-user.dtsi
+DTS_FILE                           := ${DTS}/system-top.dts
+DTB_FILE                           := ${DTS}/system-top.dtb
+DUMP_DTS_FILE                      := ${DTS}/dump.dts
+
+##############
+# Build Flow #
+##############
+.PHONY: clean help all
+
+help::
+	$(ECHO) "Makefile Usage:"
+	$(ECHO) "  make all"
+	$(ECHO) "      Command to generate everything for this design"
+	$(ECHO) ""
+	$(ECHO) "  make clean"
+	$(ECHO) "      Command to remove all the generated files."
+
+all: ${DTG} ${DTB_FILE}
+
+${DTB_FILE}: ${XSA_FILE}
+	make build_dts
+#	make include_board
+	make include_dtsi
+#	make build_xsct
+	make build_dtb
+	make dump_dts
+
+${DTG}:
+	git clone https://github.com/Xilinx/${DTG}.git
+	cd ${DTG} && git checkout ${DTG_VERSION}
+
+${DTC}:
+	git clone https://git.kernel.org/pub/scm/utils/dtc/dtc.git ${DTC}
+	cd ${DTC} && make
+	export PATH=$PATH:${DTC_PATH}
+
+build_xsct:
+	xsct -eval "createdts -hw ${XSA_FILE} -zocl -out . -platform-name vck190_thin -git-branch xlnx_rel_v2022.2 -dtsi ${DTSI_FILE} -compile"
+	cp ./vck190_thin/psv_cortexa72_0/device_tree_domain/bsp/system.dtb ${DTB_FILE}
+
+build_dts:
+	rm -rf ${DTS}
+	xsct -eval "source src/build_dts.tcl; build_dts $(XSA_FILE) ${DTS}"	
+
+include_board:
+	xsct -eval "source src/build_dts.tcl; include_board ${DTS}"
+
+include_dtsi:
+	xsct -eval "source src/build_dts.tcl; include_dtsi ${DTSI_DIR} $(DTSI_FILE) ${DTS}"
+	
+build_dtb:
+	rm -rf ${DTB_FILE}
+	gcc -I ${DTS} -E -nostdinc -undef -D__DTS__ -x assembler-with-cpp -o ${DTS_FILE}.tmp ${DTS_FILE}
+	dtc -I dts -O dtb -@ -o ${DTB_FILE} ${DTS_FILE}.tmp
+
+dump_dts:
+	dtc -I dtb -O dts -o ${DUMP_DTS_FILE} ${DTB_FILE}
+
+clean:
+	rm -rf .Xil ${DTS}
+	rm -rf vck190_thin
+
+ultraclean:
+	rm -rf ${DTG}
+	rm -rf ${DTC}
+	make clean
+

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
@@ -69,7 +69,7 @@ ${DTC}:
 
 build_xsct:
 	$(ECHO) "dtg/build_xsct: Currently errors out, but should be the prefered method"
-	xsct -eval "createdts -hw ${XSA_FILE} -zocl -out . -platform-name vck190_thin -git-branch xlnx_rel_v2022.2 -dtsi ${DTSI_FILE} -compile"
+	xsct -eval "createdts -hw ${XSA_FILE} -zocl -out . -platform-name vck190_thin -git-branch xlnx_rel_v2022.2 -dtsi ${DTSI_DIR}/${DTSI_FILE} -compile"
 	cp ./vck190_thin/psv_cortexa72_0/device_tree_domain/bsp/system.dtb ${DTB_FILE}
 
 build_dts:

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/src/build_dts.tcl
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/src/build_dts.tcl
@@ -1,0 +1,57 @@
+proc build_dts {xsa dts} {
+	hsi::open_hw_design $xsa
+	hsi::set_repo_path ./
+	set proc 0
+	foreach procs [hsi::get_cells -hier -filter {IP_TYPE==PROCESSOR}] {
+		if {[regexp {cortex} $procs]} {
+			set proc $procs
+			break
+		}
+	}
+	if {$proc != 0} {
+		puts "Targeting $proc"
+		hsi::create_sw_design device-tree -os device_tree -proc $proc
+    hsi::set_property CONFIG.dt_zocl true [hsi::get_os]
+		hsi::generate_target -dir $dts
+	} else {
+		puts "Error: No processor found in XSA file"
+	}
+	hsi::close_hw_design [hsi::current_hw_design]
+}
+
+proc include_board {dts} {
+  foreach lib [glob -nocomplain -directory device-tree-xlnx/device_tree/data/kernel_dtsi/2022.2/include/dt-bindings -type d *] {
+    if {![file exists $dts/include/dt-bindings/[file tail $lib]]} {
+      file copy -force $lib $dts/include/dt-bindings
+    }
+  }
+  set dtsi_files [glob -nocomplain -directory device-tree-xlnx/device_tree/data/kernel_dtsi/2022.2/versal -type f *versal*]
+  if {[llength $dtsi_files] != 0} {
+    puts "Info: Board file: versal is found"
+    file copy -force [lindex $dtsi_files end] $dts
+    set fileId [open $dts/system-user.dtsi "w"]
+    puts $fileId "/include/ \"[file tail [lindex $dtsi_files end]]\""
+    puts $fileId "/ {"
+    puts $fileId "};"
+    close $fileId
+  } else {
+    puts "Info: Board file: versal is not found and will not be added to the system-top.dts"
+  }
+}
+
+proc include_dtsi {dtsi_dir dtsi_file dts} {
+	if {[file exists $dtsi_dir/$dtsi_file]} {
+		file copy -force $dtsi_dir/$dtsi_file $dts
+		set fp [open $dts/system-top.dts r]
+		set file_data [read $fp]
+		close $fp
+		set fileId [open $dts/system-top.dts "w"]
+		set data [split $file_data "\n"]
+		foreach line $data {
+		     puts $fileId $line
+		}
+		puts $fileId "#include \"$dtsi_file\""
+		close $fileId
+	}
+}
+

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/src/system-user.dtsi
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/src/system-user.dtsi
@@ -1,0 +1,77 @@
+/*
+  Copyright 2021 Xilinx, Inc.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+      http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/ 
+
+/ {
+  compatible = "xlnx,versal";
+  model = "Xilinx custom-vck190";
+  chosen {
+bootargs = "console=ttyAMA0  earlycon=pl011,mmio32,0xFF000000,115200n8 clk_ignore_unused root=/dev/mmcblk0p2 rw rootwait cma=512M";
+		stdout-path = "serial0:115200";
+  };
+
+	aliases {
+			serial0 = &serial0;
+			ethernet0 = &gem0;
+			i2c0 = &i2c0;
+			i2c1 = &i2c1;
+			mmc0 = &sdhci1;
+			usb0 = &usb0;
+  };
+
+  reserved-memory {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    ranges;
+    lpddr_memory: buffer@0 {
+      no-map;
+      reg = <0x500 0x0 0x2 0x0>;
+    };
+  };
+};
+
+&gem0 { /* PMC_MIO_48, LPD_MIO0-11/24/25 */
+	phy-handle = <&phy1>; /* u128 */
+	phy-mode = "rgmii-id";
+	phy1: phy@1 {
+		reg = <1>;
+		ti,rx-internal-delay = <0xb>;
+		ti,tx-internal-delay = <0xa>;
+		ti,fifo-depth = <1>;
+		ti,dp83867-rxctrl-strap-quirk;
+	};
+};
+
+&sdhci1 { /* emmc MIO 0-13 - MTFC8GAKAJCN */
+	non-removable;
+	disable-wp;
+	bus-width = <8>;
+	xlnx,mio-bank = <0>;
+	no-1-8-v;
+};
+
+&i2c0 { /* PMC_MIO46/47 */
+	clock-frequency = <400000>;
+};
+
+&i2c1 { /* PMC_MIO44/45 */
+	clock-frequency = <400000>;
+};
+
+&usb0 { /* PMC_MIO13_500 - PMC_MIO25 USB 2.0 */
+	xlnx,usb-polarity = <0x0>;
+	xlnx,usb-reset-mode = <0x0>;
+};
+

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/petalinux/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/petalinux/Makefile
@@ -59,6 +59,7 @@ ${PROJ_DIR}: ${XSA_DIR}/${XSA_FILE}
 	make update_build
 	make update_bootimage
 	make update_sysroot
+	make dump_dts
 
 create: 
 	cd ../ && petalinux-create -t project --template versal -n ${LINUX_MACHINE} --tmpdir ${LINUX_TMP_DIR}
@@ -113,7 +114,7 @@ ifeq (${LINUX_BUILD_SOURCES}, local)
 	cd ${PROJ_DIR} && petalinux-config  --silentconfig
 endif
 
-dump-dts:
+dump_dts:
 	cd ${PROJ_DIR}/images/linux && dtc -I dtb -O dts -o dump.dts system.dtb
 
 clean:

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/platform/hw/platform_xsa.tcl
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/platform/hw/platform_xsa.tcl
@@ -105,7 +105,7 @@ set_property platform.run.steps.phys_opt_design.tcl.post [get_files post_physopt
 ## ===================================================================================
 ## Add hardware emulation support
 ## ===================================================================================
-set_property PLATFORM.LINK_XP_SWITCHES_DEFAULT [list param:compiler.skipTimingCheckAndFrequencyScaling=true param:hw_emu.enableProfiling=false] [current_project]
+set_property PLATFORM.LINK_XP_SWITCHES_DEFAULT [list param:hw_emu.enableProfiling=false] [current_project]
 set_property SELECTED_SIM_MODEL tlm [get_bd_cells /cips_0]
 set_property SELECTED_SIM_MODEL tlm [get_bd_cells /cips_noc]
 set_property SELECTED_SIM_MODEL tlm [get_bd_cells /noc_ddr4]

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/platform/hw/src/dr.bd.tcl
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/platform/hw/src/dr.bd.tcl
@@ -450,6 +450,7 @@ proc create_root_design { parentCell } {
     CONFIG.PRIM_SOURCE {No_buffer} \
     CONFIG.RESET_TYPE {ACTIVE_LOW} \
     CONFIG.USE_PHASE_ALIGNMENT {true} \
+    CONFIG.CE_TYPE {HARDSYNC} \
   ] $clk_wizard_0
 
 

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/vitis/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/vitis/Makefile
@@ -18,19 +18,19 @@ ECHO                  := @echo
 
 TARGET                ?= hw
 PLATFORM_CUSTOM       ?= vck190_thin
-XPFM_LINUX_PRE_BUILDS ?= false
+LINUX_PRE_BUILDS      ?= false
 
 XPFM_EXPORT           := $(abspath ../platform/sw/build/${PLATFORM_CUSTOM}/export/${PLATFORM_CUSTOM})
 XPFM                  := ${XPFM_EXPORT}/${PLATFORM_CUSTOM}.xpfm
 
-ifeq (${XPFM_LINUX_PRE_BUILDS}, false)
 LINUX_ABS_PATH        := $(abspath ${XPFM_EXPORT}/sw)
 LINUX_KERNEL          := ${LINUX_ABS_PATH}/Image
+LINUX_DTB             := ${LINUX_ABS_PATH}/system.dtb
+
+ifeq (${LINUX_PRE_BUILDS}, false)
 LINUX_ROOTFS          := ${LINUX_ABS_PATH}/rootfs.cpio.gz.u-boot
 LINUX_ROOTFS_TYPE     := fat32
 else
-LINUX_ABS_PATH        := $(abspath ${SDKTARGETSYSROOT}/../..)
-LINUX_KERNEL          := ${LINUX_ABS_PATH}/Image
 LINUX_ROOTFS          := ${LINUX_ABS_PATH}/rootfs.ext4
 LINUX_ROOTFS_TYPE     := ext4
 endif
@@ -88,7 +88,7 @@ ${BUILD_DIR}/${XSA}: ${XO} ${GRAPH_O} ${SYSTEM_CFG}
 			--output ${XSA} \
 			|& tee vpp_link.log
 
-${SD_CARD}: ${BUILD_DIR}/${XSA} ${PS_EXE} ${GRAPH_O} ${LINUX_KERNEL} ${LINUX_ROOTFS}
+${SD_CARD}: ${BUILD_DIR}/${XSA} ${PS_EXE} ${GRAPH_O} ${LINUX_KERNEL} ${LINUX_ROOTFS} ${LINUX_DTB}
 	cd ${BUILD_DIR} && \
 		v++ --package --debug --save-temps \
 			--target ${TARGET} \


### PR DESCRIPTION
- Allows to integrate your own Base Platform and still using the Linux pre-builds (or the other way around)
- Allows to build Base Platform and Linux or allows to use the pre-builds for both
- Some improvements done on the clk-pll settings
- Added some more guards to Error out when something is not setup correctly from the start