### PR TITLE
PFM/D/KV260: Set workspace after launching xsct

### DIFF
--- a/Vitis_Platform_Creation/Design_Tutorials/01-Edge-KV260/step2.md
+++ b/Vitis_Platform_Creation/Design_Tutorials/01-Edge-KV260/step2.md
@@ -137,6 +137,7 @@ If you need to do system customization, please take the following steps as refer
    source <Vitis_tool_install_dir>/settings64.sh
    cd kv260_vitis_platform
    xsct
+   setws .
    createdts -hw ../kv260_hardware_platform/kv260_hardware_platform.xsa -zocl \
    -platform-name mydevice -git-branch xlnx_rel_v2022.1 -overlay -compile
    ```


### PR DESCRIPTION
If "setws" is not called after xsct is launched, the "createdts" command without the output directory specified will throw an error indicating the workspace is not set. The error message is: "Error: please set a workspace or provide -out directory"
According to the other parts of the tutorial, the workspace folder is just the current folder. So simply calling "setws ." would solve the issue.