### PR TITLE
PFM: add -out option to specify the output directory when using createdts

### DIFF
--- a/Vitis_Platform_Creation/Design_Tutorials/01-Edge-KV260/step2.md
+++ b/Vitis_Platform_Creation/Design_Tutorials/01-Edge-KV260/step2.md
@@ -137,8 +137,7 @@ If you need to do system customization, please take the following steps as refer
    source <Vitis_tool_install_dir>/settings64.sh
    cd kv260_vitis_platform
    xsct
-   setws .
-   createdts -hw ../kv260_hardware_platform/kv260_hardware_platform.xsa -zocl \
+   createdts -hw ../kv260_hardware_platform/kv260_hardware_platform.xsa -zocl -out . \
    -platform-name mydevice -git-branch xlnx_rel_v2022.1 -overlay -compile
    ```
 
@@ -148,6 +147,7 @@ If you need to do system customization, please take the following steps as refer
    -  `-hw`: Hardware XSA file with path
    -  `-git-branch`: device tree branch
    -  `-zocl`: enable the zocl driver support
+   -  `-out`: specify the output directory
    -  `-overlay`: enable the device tree overlay support
    -  `-compile`: specify the option to compile the device tree to DTB file
 

--- a/Vitis_Platform_Creation/Design_Tutorials/02-Edge-AI-ZCU104/step2.md
+++ b/Vitis_Platform_Creation/Design_Tutorials/02-Edge-AI-ZCU104/step2.md
@@ -188,7 +188,7 @@ Besides uboot in common image does not have default environment variables. So up
 
    ```bash
    createdts -hw ../zcu104_hardware_platform/zcu104_custom_platform_hw.xsa -zocl  -platform-name mydevice \
-    -git-branch xlnx_rel_v2022.2 -board  zcu104-revc  -dtsi system-user.dtsi -compile
+    -out . -git-branch xlnx_rel_v2022.2 -board  zcu104-revc  -dtsi system-user.dtsi -compile
    ```
    The `createdts` command needs the following input values:
 
@@ -197,6 +197,7 @@ Besides uboot in common image does not have default environment variables. So up
    -  `-git-branch`: device tree branch
    -  `-board`: board name of the device. You can check the board name at <DTG Repo>/device_tree/data/kernel_dtsi.
    -  `-zocl`: enable the zocl driver support
+   -  `-out`: specify the output directory
    -  `-dtsi`: Add user's device tree file support
    -  `-compile`: specify the option to compile the device tree
 

--- a/Vitis_Platform_Creation/Design_Tutorials/03_Edge_VCK190/step2.md
+++ b/Vitis_Platform_Creation/Design_Tutorials/03_Edge_VCK190/step2.md
@@ -98,6 +98,7 @@ Utilize XSCT tool to execute one command to generate device tree files:
    -  `-platform-name`: Platform name
    -  `-git-branch`: device tree branch
    -  `-board`: board name of the device. You can check the board name at <DTG Repo>/device_tree/data/kernel_dtsi.
+   -  `-out`: specify the output directory
    -  `-zocl`: enable the zocl driver support
    -  `-dtsi`: Add user's device tree file support
    -  `-compile`: specify the option to compile the device tree


### PR DESCRIPTION
To prevent errors if user remove `setws .` from the tcl script and only run createdts command.