### PR TITLE
AIE/D/01-lenet: Removed unnecessary link to the AIE secure site

### DIFF
--- a/AI_Engine_Development/Design_Tutorials/01-aie_lenet_tutorial/README.md
+++ b/AI_Engine_Development/Design_Tutorials/01-aie_lenet_tutorial/README.md
@@ -106,8 +106,6 @@ Note: This tutorial targets the VCK190 Production board (see https://www.xilinx.
 
 Tools Documentation:
 
-* [AI Engine Tools lounge](https://www.xilinx.com/member/versal_ai_engines.html#documentation)
-
 * [AI Engine Documentation](https://www.xilinx.com/html_docs/xilinx2022.2/vitis_doc/yii1603912637443.html)
 
 To build and run the Lenet tutorial, you will need the following tools downloaded/installed:


### PR DESCRIPTION
Removed link to the lounge from the installing the tools section