### PR TITLE
HW/D/08-aurora: address race between kernel starts

### DIFF
--- a/Hardware_Acceleration/Design_Tutorials/08-alveo_aurora_kernel/host/host_krnl_aurora_test.cpp
+++ b/Hardware_Acceleration/Design_Tutorials/08-alveo_aurora_kernel/host/host_krnl_aurora_test.cpp
@@ -9,6 +9,7 @@ SPDX-License-Identifier: X11
 #include <fstream>
 #include <bitset>
 #include <unistd.h>
+#include <thread>
 
 // Please use 'xbutil list' command to get the device id of the target alveo card if multiple
 //   cards are installed in the system.
@@ -176,9 +177,13 @@ int main(int argc, char *argv[]) {
    
     std::cout << "Begin data loopback transfer" << std::endl;
 
+    run_strm_dump.start();
+
+    // Give the strm_dump kernel enough time to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
     gettimeofday(&start_time, NULL);
     
-    run_strm_dump.start();
     run_strm_issue.start();
     run_strm_issue.wait();
     run_strm_dump.wait();


### PR DESCRIPTION
The strm_dump kernel needs to be up and running when the strm_issue kernel starts to transfer data across the Aurora channel. Otherwise, data will be lost and the application will deadlock, waiting for the correct amount of data on the receiver side.

In practice we observe that calling `run_strm_issue.start()` directly after `run_strm_dump.start()` does not guarantee that the strm_dump kernel is running early enough. In fact, on our system about one of five invocations of this example reproduced the deadlock. Introducing a small delay of 1ms is enough to make it work reliably. We ran this modified code now for 10.000s of times without issues.

I assume this to be the problem 2 mentioned by @zhuofanzhang in #277.

It would be nice to have a cleaner solution to this than a 1ms sleep. I tried to determine via XRT if the strm_dump kernel is actually running but `run_strm_dump.state()` always returns `ERT_CMD_STATE_NEW`, no matter how long I wait.

cc @mellich @papeg