### PR TITLE
HW/D/08-aurora: use correct refclk on all boards

### DIFF
--- a/Hardware_Acceleration/Design_Tutorials/08-alveo_aurora_kernel/krnl_aurora_test.cfg
+++ b/Hardware_Acceleration/Design_Tutorials/08-alveo_aurora_kernel/krnl_aurora_test.cfg
@@ -11,12 +11,12 @@ stream_connect=strm_issue_0.data_output:krnl_aurora_0.tx_axis
 # Aurora signal connection (GT / clock)
 # ---------------------------------------
 # uncomment following lines for xilinx_u200_gen3x16_xdma_2_202110_1
-connect=io_clk_qsfp_refclka_00:krnl_aurora_0/gt_refclk
+connect=io_clk_qsfp_refclkb_00:krnl_aurora_0/gt_refclk
 connect=krnl_aurora_0/gt_port:io_gt_qsfp_00
 connect=krnl_aurora_0/init_clk:ii_level0_wire/ulp_m_aclk_freerun_ref_00
 
 # uncomment following lines for xilinx_u250_gen3x16_xdma_4_1_202210_1
-#connect=io_clk_qsfp_refclka_00:krnl_aurora_0/gt_refclk
+#connect=io_clk_qsfp_refclkb_00:krnl_aurora_0/gt_refclk
 #connect=krnl_aurora_0/gt_port:io_gt_qsfp_00
 #connect=krnl_aurora_0/init_clk:ii_level1_wire/ulp_m_aclk_freerun_ref_00
 
@@ -31,6 +31,6 @@ connect=krnl_aurora_0/init_clk:ii_level0_wire/ulp_m_aclk_freerun_ref_00
 #connect=krnl_aurora_0/init_clk:ii_level0_wire/ulp_m_aclk_freerun_ref_00
 
 # uncomment following lines for xilinx_u280_gen3x16_xdma_1_202211_1
-#connect=io_clk_qsfp0_refclka_00:krnl_aurora_0/gt_refclk
+#connect=io_clk_qsfp0_refclkb_00:krnl_aurora_0/gt_refclk
 #connect=krnl_aurora_0/gt_port:io_gt_qsfp0_00
 #connect=krnl_aurora_0/init_clk:ii_level0_wire/ulp_m_aclk_freerun_ref_00


### PR DESCRIPTION
The Aurora core is configured to be fed with a clock of 161.1328125 MHz. However, on some Alveo boards it is currently fed with a 156.25 MHz clock. On those, refclka needs to be replaced by refclkb, which actually represents the 161.1328125 MHz clock.

This change directly affects the throughput (measured on a U280):

Before: 4594.95 MB/s
After:  4733.95 MB/s

The latter result is closer to the expected 40 Gbps (5000 MB/s).

While preparing this change, I went through the Development Target Platforms and the Vivado XDC files for all of the supported Alveo boards. However, I could only actually test this change on the U280. If you have the possibility to test this on the other boards, that might be a good idea before merging.

cc @Mellich @papeg