### PR TITLE
GS/PFM: fix typo for XSA filename in readme

### DIFF
--- a/Getting_Started/Vitis_Platform/README.md
+++ b/Getting_Started/Vitis_Platform/README.md
@@ -109,11 +109,11 @@ This is a quick start for Versal platform creation. If you have queries about so
    Then execute `createdts` command in XSCT console like the following:
 
    ```bash
-   createdts -hw <full path>/vck190_custom_hw.xsa -out . -zocl \
+   createdts -hw <full path>/vck190_custom.xsa -out . -zocl \
    -platform-name mydevice -git-branch xlnx_rel_v2023.1 -board versal-vck190-reva-x-ebm-02-reva -dtsi system-user.dtsi -compile   
    ```
 
-   Notice that `-hw ` option is your XSA file generated in step1 located in your Vivado Project directory named `vck190_custom_hw.xsa`. Besides, the following information would show in XSCT console. Ignore the following warning and that means you succeed to get system.dtb file, which is located in `mydevice/psv_cortexa72_0/device_tree_domain/bsp/`.
+   Notice that `-hw ` option is your XSA file generated in step1 located in your Vivado Project directory named `vck190_custom.xsa`. Besides, the following information would show in XSCT console. Ignore the following warning and that means you succeed to get system.dtb file, which is located in `mydevice/psv_cortexa72_0/device_tree_domain/bsp/`.
 
    ```bash
    pl.dtsi:9.21-46.4: Warning (unit_address_vs_reg): /amba_pl@0: node has a unit name, but no reg property


### PR DESCRIPTION
Hey, the `vck190_custom_hw.xsa` in the code doesn't align with `vck190_custom.xsa` in the context.