### PR TITLE
DevContrib/01-Thin_PFM: Some minor updates

### DIFF
--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/dtg/Makefile
@@ -4,13 +4,13 @@
 #
 
 
-ECHO                               = @echo
+ECHO                                = @echo
 
-################################################################################
-# Variables needed for AMD/XILINX tools version checking, PLEASE DO NOT MODIFY #
-################################################################################
+BOARD_NAME                         ?= vck190
+PLATFORM_CUSTOM                    ?= ${BOARD_NAME}_thin
+
 DTG                                := device-tree-xlnx
-DTG_VERSION                        := xlnx_rel_v2022.2
+DTG_VERSION                        := xlnx_rel_v2023.2
 
 DTC                                := dtc
 DTC_PATH                           := $(abspath ${DTC})
@@ -58,8 +58,8 @@ ${DTC}:
 
 build_xsct:
 	$(ECHO) "dtg/build_xsct: Currently errors out, but should be the prefered method"
-	xsct -eval "createdts -hw ${XSA_FILE} -zocl -out . -platform-name vck190_thin -git-branch xlnx_rel_v2022.2 -dtsi ${DTSI_DIR}/${DTSI_FILE} -compile"
-	cp ./vck190_thin/psv_cortexa72_0/device_tree_domain/bsp/system.dtb ${DTB_FILE}
+	xsct -eval "createdts -hw ${XSA_FILE} -zocl -out . -platform-name ${PLATFORM_CUSTOM} -git-branch ${DTG_VERSION} -dtsi ${DTSI_DIR}/${DTSI_FILE} -compile"
+	cp ./${PLATFORM_CUSTOM}/psv_cortexa72_0/device_tree_domain/bsp/system.dtb ${DTB_FILE}
 
 build_dts:
 	$(ECHO) "dtg/build_dts: Building the dts from the supplied xsa"
@@ -85,7 +85,7 @@ dump_dts:
 
 clean:
 	rm -rf .Xil ${DTS}
-	rm -rf vck190_thin
+	rm -rf ${PLATFORM_CUSTOM}
 
 ultraclean:
 	rm -rf ${DTG}

--- a/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/petalinux/Makefile
+++ b/Developer_Contributed/01-Versal_Custom_Thin_Platform_Extensible_System/linux/petalinux/Makefile
@@ -68,6 +68,7 @@ update_device_tree:
 	cp -r ${SRC_DIR_DEVICE_TREE}/* ${DEST_DIR_DEVICE_TREE}/
 
 update_config:
+	chmod 777 ${CFG}
 	${CFG} --file ${FILE_MAIN_CFG}      --set-str CONFIG_SUBSYSTEM_RFS_FORMATS "cpio cpio.gz cpio.gz.u-boot tar.gz jffs2 ext4"
 	${CFG} --file ${FILE_ROOT_FS_CFG}   --keep-case --enable  xrt
 	${CFG} --file ${FILE_ROOT_FS_CFG}   --keep-case --enable  xrt-dev


### PR DESCRIPTION
- Using 2023.2 for dtg generation
- Using ${PLATFORM_CUSTOM} instead of vck190_thin for dtg generation
- Making linux/petalinux/src/config executable before usage